### PR TITLE
Building using Ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(libremidi
   VERSION 4.0
   DESCRIPTION "A cross-platform MIDI library"

--- a/include/libremidi/backends/jack/helpers.hpp
+++ b/include/libremidi/backends/jack/helpers.hpp
@@ -13,7 +13,6 @@
 
 #include <atomic>
 #include <semaphore>
-#include <cassert>
 
 namespace libremidi
 {
@@ -250,8 +249,6 @@ struct jack_helpers : jack_client
 
     // 3. Now we are sure that the client is not going to use the port anymore
     jack_port_unregister(this->client, port_ptr);
-
-    assert(this->port.impl->load() == nullptr);
   }
 };
 }

--- a/include/libremidi/backends/jack/helpers.hpp
+++ b/include/libremidi/backends/jack/helpers.hpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <semaphore>
+#include <cassert>
 
 namespace libremidi
 {


### PR DESCRIPTION
The master branch won't build on a stock Ubuntu 22.04 without a couple of changes. I dropped the CMake requirement back a couple of minor versions. I added an include to stop an error with raising asserts.

Changes:

CMake version reduced to 3.22 for Ubuntu 22.04
<cassert> include added to enable it to compile.