### PR TITLE
Fixes (most) -Wall and -Wextra warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,23 @@ else()
   set(_private PRIVATE)
 endif()
 
+if(MSVC)
+	set(WARNING_FLAGS
+			/W4
+	)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+	set(WARNING_FLAGS
+			-Werror    # Turns all warnings into errors
+			-Wall   # Enable most warning messages.
+			-Wextra # Print extra (possibly unwanted) warnings.
+			#-Wpedantic # Issue warnings needed for strict compliance to the standard.
+	)
+else()
+	message(WARNING "CMake flags for compiler aren't set for compiler ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+target_compile_options(libremidi PUBLIC ${WARNING_FLAGS})
+
 add_library(libremidi::libremidi ALIAS libremidi)
 
 if(LIBREMIDI_SLIM_MESSAGE GREATER 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(LIBREMIDI_FIND_BOOST "Actively look for Boost" OFF)
 option(LIBREMIDI_EXAMPLES "Enable examples" OFF)
 option(LIBREMIDI_TESTS "Enable tests" OFF)
 option(LIBREMIDI_CI "To be enabled only in CI, some tests cannot run there" OFF)
+option(LIBREMIDI_NO_WARNINGS "Disables warnings from library compilation" OFF)
 
 ### C++ features ###
 if(NOT CMAKE_CXX_STANDARD)
@@ -178,22 +179,24 @@ else()
   set(_private PRIVATE)
 endif()
 
-if(MSVC)
-	set(WARNING_FLAGS
-			/W4
-	)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-	set(WARNING_FLAGS
-			-Werror    # Turns all warnings into errors
-			-Wall   # Enable most warning messages.
-			-Wextra # Print extra (possibly unwanted) warnings.
-			#-Wpedantic # Issue warnings needed for strict compliance to the standard.
-	)
-else()
-	message(WARNING "CMake flags for compiler aren't set for compiler ${CMAKE_CXX_COMPILER_ID}")
-endif()
+if(NOT LIBREMIDI_NO_WARNINGS)
+	if(MSVC)
+		set(WARNING_FLAGS
+				/W4
+		)
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+		set(WARNING_FLAGS
+				-Werror    # Turns all warnings into errors
+				-Wall   # Enable most warning messages.
+				-Wextra # Print extra (possibly unwanted) warnings.
+				#-Wpedantic # Issue warnings needed for strict compliance to the standard.
+		)
+	else()
+		message(WARNING "CMake flags for compiler aren't set for compiler ${CMAKE_CXX_COMPILER_ID}")
+	endif()
 
-target_compile_options(libremidi PUBLIC ${WARNING_FLAGS})
+	target_compile_options(libremidi PRIVATE ${WARNING_FLAGS})
+endif ()
 
 add_library(libremidi::libremidi ALIAS libremidi)
 

--- a/include/libremidi/backends/alsa_raw/config.hpp
+++ b/include/libremidi/backends/alsa_raw/config.hpp
@@ -45,7 +45,7 @@ struct LIBREMIDI_EXPORT chunking_parameters
    */
   std::function<bool(std::chrono::microseconds, int)> wait = chunking_parameters::default_wait;
 
-  static bool default_wait(std::chrono::microseconds time_to_wait, int written_bytes)
+  static bool default_wait(std::chrono::microseconds time_to_wait, int /*written_bytes*/)
   {
     std::this_thread::sleep_for(time_to_wait);
     return true;

--- a/include/libremidi/backends/alsa_raw/midi_out.hpp
+++ b/include/libremidi/backends/alsa_raw/midi_out.hpp
@@ -133,7 +133,7 @@ public:
     const std::size_t chunk_size = std::min(get_chunk_size(), size);
 
     // Send the first buffer
-    int len = chunk_size;
+    std::size_t len = chunk_size;
 
     if (!write(data, len))
       return;
@@ -156,10 +156,10 @@ public:
         return;
 
       // Write more data
-      int len = end - data;
+      len = end - data;
 
       // Maybe until the end of the sysex
-      if (auto sysex_end = (unsigned char*)memchr(data, 0xf7, len))
+      if (const auto sysex_end = static_cast<const unsigned char*>(memchr(data, 0xf7, len)))
         len = sysex_end - data + 1;
 
       if (len > chunk_size)

--- a/include/libremidi/backends/alsa_seq/helpers.hpp
+++ b/include/libremidi/backends/alsa_seq/helpers.hpp
@@ -222,7 +222,7 @@ struct alsa_data
   }
 
   [[nodiscard]] int create_port(
-      auto& self, std::string_view portName, unsigned int caps, unsigned int type,
+      auto& /*self*/, std::string_view portName, unsigned int caps, unsigned int type,
       std::optional<int> queue)
   {
     if (this->vport < 0)

--- a/include/libremidi/backends/dummy.hpp
+++ b/include/libremidi/backends/dummy.hpp
@@ -10,7 +10,7 @@ namespace libremidi
 class observer_dummy : public observer_api
 {
 public:
-  explicit observer_dummy(const auto& configuration, dummy_configuration) { }
+  explicit observer_dummy(const auto& /*configuration*/, dummy_configuration) { }
 
   ~observer_dummy() { }
   libremidi::API get_current_api() const noexcept override { return libremidi::API::DUMMY; }
@@ -29,7 +29,7 @@ public:
   }
 
   libremidi::API get_current_api() const noexcept override { return libremidi::API::DUMMY; }
-  bool open_port(const input_port& pt, std::string_view local_port_name) override { return true; }
+  bool open_port(const input_port& /*pt*/, std::string_view /*local_port_name*/) override { return true; }
   bool open_virtual_port(std::string_view /*portName*/) override { return true; }
   void close_port() override { }
   void set_client_name(std::string_view /*clientName*/) override { }
@@ -47,7 +47,7 @@ public:
   }
 
   libremidi::API get_current_api() const noexcept override { return libremidi::API::DUMMY; }
-  bool open_port(const output_port& pt, std::string_view local_port_name) override { return true; }
+  bool open_port(const output_port& /*pt*/, std::string_view /*local_port_name*/) override { return true; }
   bool open_virtual_port(std::string_view /*portName*/) override { return true; }
   void close_port() override { }
   void set_client_name(std::string_view /*clientName*/) override { }

--- a/include/libremidi/backends/jack/helpers.hpp
+++ b/include/libremidi/backends/jack/helpers.hpp
@@ -4,7 +4,7 @@
   #include <weakjack/weak_libjack.h>
 #elif __has_include(<weak_libjack.h>)
   #include <weak_libjack.h>
-#elif __has_include(<jack/jack.h>)
+#elif __has_include(<jack/jack.h> )
   #include <jack/jack.h>
   #include <jack/midiport.h>
   #include <jack/ringbuffer.h>
@@ -39,7 +39,7 @@ struct jack_client
     }
     else
     {
-      auto short_name = jack_port_short_name(port);
+      const auto short_name = jack_port_short_name(port);
       if (short_name && strlen(short_name) > 0)
         return short_name;
       return jack_port_name(port);
@@ -51,7 +51,7 @@ struct jack_client
       -> std::conditional_t<Input, input_port, output_port>
   {
     return {{
-        .client = std::uintptr_t(client),
+        .client = reinterpret_cast<std::uintptr_t>(client),
         .port = 0,
         .manufacturer = "",
         .device_name = "",
@@ -61,7 +61,7 @@ struct jack_client
   }
 
   template <bool Input>
-  static auto get_ports(jack_client_t* client, const char* pattern, JackPortFlags flags) noexcept
+  static auto get_ports(jack_client_t* client, const char* pattern, const JackPortFlags flags) noexcept
       -> std::vector<std::conditional_t<Input, input_port, output_port>>
   {
     std::vector<std::conditional_t<Input, input_port, output_port>> ret;
@@ -214,7 +214,7 @@ struct jack_helpers : jack_client
     if (portName.empty())
       portName = flags & JackPortIsInput ? "i" : "o";
 
-    if (self.configuration.client_name.size() + portName.size() + 1 + 1 >= jack_port_name_size())
+    if (self.configuration.client_name.size() + portName.size() + 2u >= static_cast<size_t>(jack_port_name_size()))
     {
       self.template error<invalid_use_error>(
           self.configuration, "JACK: port name length limit exceeded");

--- a/include/libremidi/backends/jack/midi_in.hpp
+++ b/include/libremidi/backends/jack/midi_in.hpp
@@ -72,7 +72,7 @@ public:
   }
 
   void set_timestamp(
-      jack_nframes_t frame, jack_nframes_t start_frames, jack_time_t abs_usec,
+      jack_nframes_t frame, jack_nframes_t start_frames, jack_time_t /*abs_usec*/,
       libremidi::message& msg) noexcept
   {
     switch (configuration.timestamps)

--- a/include/libremidi/backends/jack/observer.hpp
+++ b/include/libremidi/backends/jack/observer.hpp
@@ -185,8 +185,8 @@ public:
 
     jack_set_port_rename_callback(
         this->client,
-        +[](jack_port_id_t p, const char* old_name, const char* new_name, void* arg) {
-          auto& self = *(observer_jack*)arg;
+        +[](jack_port_id_t p, const char* /*old_name*/, const char* /*new_name*/, void* arg) {
+      const auto& self = *static_cast<observer_jack*>(arg);
 
           auto port = jack_port_by_id(self.client, p);
           if (!port)

--- a/include/libremidi/backends/winmm/helpers.hpp
+++ b/include/libremidi/backends/winmm/helpers.hpp
@@ -35,8 +35,8 @@ inline std::string ConvertToUTF8(const TCHAR* str)
   int length = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
   if (length)
   {
-    u8str.assign(length - 1, 0);
-    length = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &u8str[0], length, nullptr, nullptr);
+    u8str.assign(static_cast<std::string::size_type>(length - 1), 0);
+    /*length =*/ WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &u8str[0], length, nullptr, nullptr);
   }
   return u8str;
 }

--- a/include/libremidi/backends/winmm/midi_in.hpp
+++ b/include/libremidi/backends/winmm/midi_in.hpp
@@ -64,7 +64,7 @@ public:
   bool do_open(unsigned int portNumber)
   {
     MMRESULT result = midiInOpen(
-        &this->inHandle, portNumber, reinterpret_cast<DWORD_PTR>(&midiInputCallback), reinterpret_cast<DWORD_PTR>(this),
+        &this->inHandle, portNumber, std::bit_cast<DWORD_PTR>(&midiInputCallback), std::bit_cast<DWORD_PTR>(this),
         CALLBACK_FUNCTION);
     if (result != MMSYSERR_NOERROR)
     {
@@ -78,7 +78,7 @@ public:
     this->sysexBuffer.resize(bufferCount);
     for (std::size_t i = 0; i < bufferCount; ++i)
     {
-      this->sysexBuffer[i] = reinterpret_cast<MIDIHDR*>(new char[sizeof(MIDIHDR)]);
+      this->sysexBuffer[i] = new MIDIHDR;
       this->sysexBuffer[i]->lpData = new char[configuration.sysex_buffer_size];
       this->sysexBuffer[i]->dwBufferLength = static_cast<DWORD>(configuration.sysex_buffer_size);
       this->sysexBuffer[i]->dwUser = i; // We use the dwUser parameter as buffer indicator

--- a/include/libremidi/backends/winmm/midi_in.hpp
+++ b/include/libremidi/backends/winmm/midi_in.hpp
@@ -64,7 +64,7 @@ public:
   bool do_open(unsigned int portNumber)
   {
     MMRESULT result = midiInOpen(
-        &this->inHandle, portNumber, (DWORD_PTR)&midiInputCallback, (DWORD_PTR)this,
+        &this->inHandle, portNumber, reinterpret_cast<DWORD_PTR>(&midiInputCallback), reinterpret_cast<DWORD_PTR>(this),
         CALLBACK_FUNCTION);
     if (result != MMSYSERR_NOERROR)
     {
@@ -74,12 +74,13 @@ public:
     }
 
     // Allocate and init the sysex buffers.
-    this->sysexBuffer.resize(configuration.sysex_buffer_count);
-    for (int i = 0; i < configuration.sysex_buffer_count; ++i)
+    const auto bufferCount = static_cast<std::size_t>(configuration.sysex_buffer_count);
+    this->sysexBuffer.resize(bufferCount);
+    for (std::size_t i = 0; i < bufferCount; ++i)
     {
-      this->sysexBuffer[i] = (MIDIHDR*)new char[sizeof(MIDIHDR)];
+      this->sysexBuffer[i] = reinterpret_cast<MIDIHDR*>(new char[sizeof(MIDIHDR)]);
       this->sysexBuffer[i]->lpData = new char[configuration.sysex_buffer_size];
-      this->sysexBuffer[i]->dwBufferLength = configuration.sysex_buffer_size;
+      this->sysexBuffer[i]->dwBufferLength = static_cast<DWORD>(configuration.sysex_buffer_size);
       this->sysexBuffer[i]->dwUser = i; // We use the dwUser parameter as buffer indicator
       this->sysexBuffer[i]->dwFlags = 0;
 
@@ -152,9 +153,9 @@ public:
       midiInReset(this->inHandle);
       midiInStop(this->inHandle);
 
-      for (int i = 0; i < configuration.sysex_buffer_count; ++i)
+      for (std::size_t i = 0; i < static_cast<std::size_t>(configuration.sysex_buffer_count); ++i)
       {
-        int res{};
+        MMRESULT res{};
 
         int wait_count = 5;
         while (
@@ -181,7 +182,7 @@ public:
       }
 
       midiInClose(this->inHandle);
-      this->inHandle = 0;
+      this->inHandle = nullptr;
       LeaveCriticalSection(&(this->_mutex));
     }
   }
@@ -206,12 +207,12 @@ private:
         }
         else
         {
-          message.timestamp = time;
+          message.timestamp = static_cast<int64_t>(time);
         }
         return;
       }
       case timestamp_mode::Absolute: {
-        msg.timestamp = ts * 1'000'000;
+        msg.timestamp = static_cast<int64_t>(ts * 1'000'000);
         break;
       }
       case timestamp_mode::SystemMonotonic: {
@@ -221,6 +222,8 @@ private:
                   .count();
         break;
       }
+      default:
+        break;
     }
   }
   static void CALLBACK midiInputCallback(
@@ -230,7 +233,7 @@ private:
     if (inputStatus != MIM_DATA && inputStatus != MIM_LONGDATA && inputStatus != MIM_LONGERROR)
       return;
 
-    auto& self = *(midi_in_winmm*)instancePtr;
+    auto& self = *reinterpret_cast<midi_in_winmm*>(instancePtr);
 
     auto& message = self.message;
 
@@ -240,7 +243,7 @@ private:
     { // Channel or system message
 
       // Make sure the first byte is a status byte.
-      unsigned char status = (unsigned char)(midiMessage & 0x000000FF);
+      const auto status = static_cast<unsigned char>(midiMessage & 0x000000FF);
       if (!(status & 0x80))
         return;
 
@@ -275,12 +278,12 @@ private:
       }
 
       // Copy bytes to our MIDI message.
-      unsigned char* ptr = (unsigned char*)&midiMessage;
+      const auto* ptr = reinterpret_cast<unsigned char*>(&midiMessage);
       message.bytes.assign(ptr, ptr + nBytes);
     }
     else
     { // Sysex message ( MIM_LONGDATA or MIM_LONGERROR )
-      MIDIHDR* sysex = (MIDIHDR*)midiMessage;
+      const auto* sysex = reinterpret_cast<MIDIHDR*>(midiMessage);
       if (!self.configuration.ignore_sysex && inputStatus != MIM_LONGERROR)
       {
         // Sysex message and we're not ignoring it

--- a/include/libremidi/backends/winmm/observer.hpp
+++ b/include/libremidi/backends/winmm/observer.hpp
@@ -88,7 +88,7 @@ protected:
 
     if (portRemovedFunc)
     {
-      for (const auto port : prevList)
+      for (const auto &port : prevList)
       {
         auto iter
             = std::ranges::find(currList, port.display_name, &port_information::display_name);
@@ -231,7 +231,7 @@ public:
 
 private:
   std::thread thread;
-  std::atomic_flag stop_flag{ATOMIC_FLAG_INIT};
+  std::atomic_flag stop_flag = ATOMIC_FLAG_INIT;
   std::binary_semaphore sema;
 };
 }

--- a/include/libremidi/client.cpp
+++ b/include/libremidi/client.cpp
@@ -4,16 +4,16 @@
 #include <libremidi/backends.hpp>
 #include <libremidi/shared_context.hpp>
 
-#if LIBREMIDI_ALSA
+#ifdef LIBREMIDI_ALSA
   #include <libremidi/backends/alsa_seq/shared_handler.hpp>
 #endif
-#if LIBREMIDI_JACK
+#ifdef LIBREMIDI_JACK
   #include <libremidi/backends/jack/shared_handler.hpp>
 #endif
 namespace libremidi
 {
 LIBREMIDI_INLINE
-shared_configurations create_shared_context(libremidi::API api, std::string_view client_name)
+shared_configurations create_shared_context(const libremidi::API api, std::string_view /*client_name*/)
 {
   switch (api)
   {

--- a/include/libremidi/client.hpp
+++ b/include/libremidi/client.hpp
@@ -17,7 +17,7 @@ struct client_configuration
   //! Set a callback function to be invoked for incoming MIDI messages.
   //! Mandatory!
   std::function<void(const libremidi::input_port&, message&&)> on_message
-      = []([[maybe_unused]] const libremidi::input_port& port, libremidi::message&&) {};
+      = [](const libremidi::input_port& /*port*/, libremidi::message&&) {};
 
   //! Observation callbacks for when ports are added or removed
   input_port_callback input_added;

--- a/include/libremidi/client.hpp
+++ b/include/libremidi/client.hpp
@@ -17,7 +17,7 @@ struct client_configuration
   //! Set a callback function to be invoked for incoming MIDI messages.
   //! Mandatory!
   std::function<void(const libremidi::input_port&, message&&)> on_message
-      = [](const libremidi::input_port& port, libremidi::message&&) {};
+      = []([[maybe_unused]] const libremidi::input_port& port, libremidi::message&&) {};
 
   //! Observation callbacks for when ports are added or removed
   input_port_callback input_added;

--- a/include/libremidi/cmidi2.hpp
+++ b/include/libremidi/cmidi2.hpp
@@ -1,6 +1,7 @@
 
 #ifndef CMIDI2_H_INCLUDED
 #define CMIDI2_H_INCLUDED
+#pragma GCC system_header // Todo: remove before commit
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/include/libremidi/detail/midi_out.hpp
+++ b/include/libremidi/detail/midi_out.hpp
@@ -18,19 +18,18 @@ public:
   midi_out_api& operator=(const midi_out_api&) = delete;
   midi_out_api& operator=(midi_out_api&&) = delete;
 
-  [[nodiscard]] virtual bool open_port(const output_port& pt, std::string_view local_port_name)
-      = 0;
+  [[nodiscard]] virtual bool open_port(const output_port& pt, std::string_view local_port_name) = 0;
 
-  virtual int64_t current_time() const noexcept { return 0; }
+  [[nodiscard]] virtual int64_t current_time() const noexcept { return 0; }
 
   virtual void send_message(const unsigned char* message, size_t size) = 0;
-  virtual void schedule_message([[maybe_unused]] int64_t ts, const unsigned char* message, size_t size)
+  virtual void schedule_message(int64_t /*ts*/, const unsigned char* message, size_t size)
   {
     return send_message(message, size);
   }
 
   virtual void send_ump(const uint32_t* message, size_t size) = 0;
-  virtual void schedule_ump([[maybe_unused]] int64_t ts, const uint32_t* ump, size_t size)
+  virtual void schedule_ump(int64_t /*ts*/, const uint32_t* ump, size_t size)
   {
     return send_ump(ump, size);
   }
@@ -45,10 +44,10 @@ class out_api : public midi_out_api
 public:
   using midi_out_api::midi_out_api;
 
-  void send_ump(const uint32_t* message, [[maybe_unused]] size_t size)
+  void send_ump(const uint32_t* message, size_t /*size*/)
   {
     uint8_t midi[65536];
-    int n = cmidi2_convert_single_ump_to_midi1(midi, sizeof(midi), (uint32_t*)message);
+    int n = cmidi2_convert_single_ump_to_midi1(midi, sizeof(midi), const_cast<uint32_t*>(message));
     if (n > 0)
       send_message(midi, n);
   }
@@ -89,6 +88,6 @@ public:
 template <typename T, typename Arg>
 std::unique_ptr<midi_out_api> make(libremidi::output_configuration&& conf, Arg&& arg)
 {
-  return std::make_unique<T>(std::move(conf), std::move(arg));
+  return std::make_unique<T>(std::move(conf), std::forward<Arg>(arg));
 }
 }

--- a/include/libremidi/detail/midi_out.hpp
+++ b/include/libremidi/detail/midi_out.hpp
@@ -24,13 +24,13 @@ public:
   virtual int64_t current_time() const noexcept { return 0; }
 
   virtual void send_message(const unsigned char* message, size_t size) = 0;
-  virtual void schedule_message(int64_t ts, const unsigned char* message, size_t size)
+  virtual void schedule_message([[maybe_unused]] int64_t ts, const unsigned char* message, size_t size)
   {
     return send_message(message, size);
   }
 
   virtual void send_ump(const uint32_t* message, size_t size) = 0;
-  virtual void schedule_ump(int64_t ts, const uint32_t* ump, size_t size)
+  virtual void schedule_ump([[maybe_unused]] int64_t ts, const uint32_t* ump, size_t size)
   {
     return send_ump(ump, size);
   }
@@ -45,7 +45,7 @@ class out_api : public midi_out_api
 public:
   using midi_out_api::midi_out_api;
 
-  void send_ump(const uint32_t* message, size_t size)
+  void send_ump(const uint32_t* message, [[maybe_unused]] size_t size)
   {
     uint8_t midi[65536];
     int n = cmidi2_convert_single_ump_to_midi1(midi, sizeof(midi), (uint32_t*)message);

--- a/include/libremidi/libremidi.hpp
+++ b/include/libremidi/libremidi.hpp
@@ -80,7 +80,7 @@ public:
   //! * api_conf can be an instance of observer_configuration,
   //!   such as jack_observer_configuration, winmm_observer_configuration, etc...
   //! * if no callbacks are passed, no secondary thread will be created unless absolutely necessary
-  explicit observer(observer_configuration conf = {}) noexcept;
+  explicit observer(const observer_configuration &conf = {}) noexcept;
   explicit observer(observer_configuration conf, std::any api_conf);
   observer(const observer&) = delete;
   observer(observer&& other) noexcept;
@@ -91,8 +91,8 @@ public:
   [[nodiscard]] libremidi::API get_current_api() const noexcept;
 
   //! Return identifiers for the available MIDI ports
-  std::vector<libremidi::input_port> get_input_ports() const noexcept;
-  std::vector<libremidi::output_port> get_output_ports() const noexcept;
+  [[nodiscard]] std::vector<libremidi::input_port> get_input_ports() const noexcept;
+  [[nodiscard]] std::vector<libremidi::output_port> get_output_ports() const noexcept;
 
 private:
   std::unique_ptr<class observer_api> impl_;
@@ -103,7 +103,7 @@ class LIBREMIDI_EXPORT midi_in
 {
 public:
   //! Construct a midi_in object with the default MIDI 1 back-end for the platform
-  explicit midi_in(input_configuration conf) noexcept;
+  explicit midi_in(const input_configuration& conf) noexcept;
 
   //! Construct a midi_in object with a configuration object for a specific MIDI 1 back-end
   //! see configuration.hpp for the available configuration types.
@@ -158,7 +158,7 @@ class LIBREMIDI_EXPORT midi_out
 {
 public:
   //! Construct a midi_out object with the default back-end for the platform
-  explicit midi_out(output_configuration conf = {}) noexcept;
+  explicit midi_out(const output_configuration& conf = {}) noexcept;
 
   //! Construct a midi_out object with a configuration object for a specific back-end
   //! see configuration.hpp for the available configuration types.

--- a/include/libremidi/libremidi.hpp
+++ b/include/libremidi/libremidi.hpp
@@ -172,13 +172,13 @@ public:
   ~midi_out();
 
   //! Returns the MIDI API specifier for the current instance of midi_out.
-  [[nodiscard]] libremidi::API get_current_api() noexcept;
+  [[nodiscard]] libremidi::API get_current_api() const noexcept;
 
   //! Open a MIDI output connection.
-  void open_port(const output_port& pt, std::string_view local_port_name = "libremidi input");
+  void open_port(const output_port& pt, std::string_view local_port_name = "libremidi input") const;
 
   //! Close an open MIDI connection (if one exists).
-  void close_port();
+  void close_port() const;
 
   //! Returns true if a port has been opened successfully with open_port or open_virtual_port
   [[nodiscard]] bool is_port_open() const noexcept;
@@ -192,23 +192,23 @@ public:
   //!
   //! \param portName An optional name for the application port that is
   //!                 used to connect to portId can be specified.
-  void open_virtual_port(std::string_view portName = "libremidi virtual port");
+  void open_virtual_port(std::string_view portName = "libremidi virtual port") const;
 
-  void set_port_name(std::string_view portName);
+  void set_port_name(std::string_view portName) const;
 
   //! Immediately send a single message out an open MIDI output port.
   /*!
       An exception is thrown if an error occurs during output or an
       output connection was not previously established.
   */
-  void send_message(const libremidi::message& message);
+  void send_message(const libremidi::message& message) const;
 
   //! Immediately send a single message to an open MIDI output port.
-  void send_message(const unsigned char* message, size_t size);
-  void send_message(std::span<const unsigned char>);
-  void send_message(unsigned char b0);
-  void send_message(unsigned char b0, unsigned char b1);
-  void send_message(unsigned char b0, unsigned char b1, unsigned char b2);
+  void send_message(const unsigned char* message, size_t size) const;
+  void send_message(std::span<const unsigned char>) const;
+  void send_message(unsigned char b0) const;
+  void send_message(unsigned char b0, unsigned char b1) const;
+  void send_message(unsigned char b0, unsigned char b1, unsigned char b2) const;
 
   //! Current time in the timestamp referential
   int64_t current_time();
@@ -218,13 +218,13 @@ public:
   void schedule_message(int64_t timestamp, const unsigned char* message, size_t size);
 
   //! Immediately send a single UMP packet to an open MIDI output port.
-  void send_ump(const uint32_t* message, size_t size);
-  void send_ump(const libremidi::ump&);
-  void send_ump(std::span<const uint32_t>);
-  void send_ump(uint32_t b0);
-  void send_ump(uint32_t b0, uint32_t b1);
-  void send_ump(uint32_t b0, uint32_t b1, uint32_t b2);
-  void send_ump(uint32_t b0, uint32_t b1, uint32_t b2, uint32_t b3);
+  void send_ump(const uint32_t* message, size_t size) const;
+  void send_ump(const libremidi::ump&) const;
+  void send_ump(std::span<const uint32_t>) const;
+  void send_ump(uint32_t b0) const;
+  void send_ump(uint32_t b0, uint32_t b1) const;
+  void send_ump(uint32_t b0, uint32_t b1, uint32_t b2) const;
+  void send_ump(uint32_t b0, uint32_t b1, uint32_t b2, uint32_t b3) const;
 
   //! Try to schedule an UMP packet later in time if the underlying API supports it
   //! (currently not implemented anywhere)

--- a/include/libremidi/message.hpp
+++ b/include/libremidi/message.hpp
@@ -95,8 +95,11 @@ struct message
 
   auto clear() noexcept { bytes.clear(); }
 
-  auto& operator[](int i) const noexcept { return bytes[i]; }
-  auto& operator[](int i) noexcept { return bytes[i]; }
+  auto& operator[](int i) const noexcept { return bytes[static_cast<unsigned int>(i)]; }
+  auto& operator[](int i) noexcept { return bytes[static_cast<unsigned int>(i)]; }
+
+  auto& operator[](std::size_t i) const noexcept { return bytes[i]; }
+  auto& operator[](std::size_t i) noexcept { return bytes[i]; }
 
   auto& front() const { return bytes.front(); }
   auto& back() const { return bytes.back(); }
@@ -138,18 +141,18 @@ struct message
   {
     if (!is_meta_event())
       return meta_event_type::UNKNOWN;
-    return (meta_event_type)bytes[1];
+    return static_cast<meta_event_type>(bytes[1]);
   }
 
   message_type get_message_type() const noexcept
   {
-    if (bytes[0] >= uint8_t(message_type::SYSTEM_EXCLUSIVE))
+    if (bytes[0] >= static_cast<uint8_t>(message_type::SYSTEM_EXCLUSIVE))
     {
-      return (message_type)(bytes[0] & 0xFF);
+      return static_cast<message_type>(bytes[0] & 0xFF);
     }
     else
     {
-      return (message_type)(bytes[0] & 0xF0);
+      return static_cast<message_type>(bytes[0] & 0xF0);
     }
   }
 
@@ -169,12 +172,12 @@ struct channel_events
       channel = 0;
     else if (channel > 15)
       channel = 15;
-    return channel;
+    return static_cast<uint8_t>(channel);
   }
 
   static uint8_t make_command(const message_type type, const int channel) noexcept
   {
-    return (uint8_t)((uint8_t)type | clamp_channel(channel));
+    return static_cast<uint8_t>(static_cast<uint8_t>(type) | clamp_channel(channel));
   }
 
   static message note_on(uint8_t channel, uint8_t note, uint8_t velocity) noexcept
@@ -200,8 +203,8 @@ struct channel_events
   static message pitch_bend(uint8_t channel, int value) noexcept
   {
     return {
-        make_command(message_type::PITCH_BEND, channel), (unsigned char)(value & 0x7F),
-        (uint8_t)((value >> 7) & 0x7F)};
+        make_command(message_type::PITCH_BEND, channel), static_cast<unsigned char>(value & 0x7F),
+        static_cast<uint8_t>((value >> 7) & 0x7F)};
   }
 
   static message pitch_bend(uint8_t channel, uint8_t lsb, uint8_t msb) noexcept
@@ -226,12 +229,12 @@ struct meta_events
 
   static message channel(int channel) noexcept
   {
-    return {0xff, 0x20, 0x01, (uint8_t)std::clamp(0, 0xff, channel - 1)};
+    return {0xff, 0x20, 0x01, static_cast<uint8_t>(std::clamp(0, 0xff, channel - 1))};
   }
 
   static message tempo(int mpqn) noexcept
   {
-    return {0xff, 81, 3, (uint8_t)(mpqn >> 16), (uint8_t)(mpqn >> 8), (uint8_t)mpqn};
+    return {0xff, 81, 3, static_cast<uint8_t>(mpqn >> 16), static_cast<uint8_t>(mpqn >> 8), static_cast<uint8_t>(mpqn)};
   }
 
   static message time_signature(int numerator, int denominator)
@@ -245,7 +248,7 @@ struct meta_events
       ++powTwo;
     }
 
-    return {0xff, 0x58, 0x04, (uint8_t)numerator, (uint8_t)powTwo, 1, 96};
+    return {0xff, 0x58, 0x04, static_cast<uint8_t>(numerator), static_cast<uint8_t>(powTwo), 1, 96};
   }
 
   // Where key index goes from -7 (7 flats, C♭ Major) to +7 (7 sharps, C♯
@@ -256,12 +259,12 @@ struct meta_events
     if (keyIndex < -7 || keyIndex > 7)
       throw std::range_error("meta_events::key_signature: out of range");
 #endif
-    return {0xff, 0x59, 0x02, (uint8_t)keyIndex, isMinor ? (uint8_t)1 : (uint8_t)0};
+    return {0xff, 0x59, 0x02, static_cast<uint8_t>(keyIndex), isMinor ? static_cast<uint8_t>(1) : static_cast<uint8_t>(0)};
   }
 
   static message song_position(int positionInBeats) noexcept
   {
-    return {0xf2, (uint8_t)(positionInBeats & 127), (uint8_t)((positionInBeats >> 7) & 127)};
+    return {0xf2, static_cast<uint8_t>(positionInBeats & 127), static_cast<uint8_t>((positionInBeats >> 7) & 127)};
   }
 };
 

--- a/include/libremidi/midi_in.cpp
+++ b/include/libremidi/midi_in.cpp
@@ -15,7 +15,7 @@ LIBREMIDI_INLINE auto make_midi_in(auto base_conf, std::any api_conf, auto backe
 
   assert(base_conf.on_message);
 
-  auto from_api = [&]<typename T>(T& backend) mutable {
+  auto from_api = [&]<typename T>(T& /*backend*/) mutable {
     if (auto conf = std::any_cast<typename T::midi_in_configuration>(&api_conf))
     {
       ptr = libremidi::make<typename T::midi_in>(std::move(base_conf), std::move(*conf));
@@ -27,7 +27,7 @@ LIBREMIDI_INLINE auto make_midi_in(auto base_conf, std::any api_conf, auto backe
   return ptr;
 }
 
-LIBREMIDI_INLINE midi_in::midi_in(input_configuration base_conf) noexcept
+LIBREMIDI_INLINE midi_in::midi_in(const input_configuration& base_conf) noexcept
 {
   for (const auto& api : available_apis())
   {

--- a/include/libremidi/midi_out.cpp
+++ b/include/libremidi/midi_out.cpp
@@ -70,19 +70,19 @@ LIBREMIDI_INLINE midi_out& midi_out::operator=(midi_out&& other) noexcept
 }
 
 LIBREMIDI_INLINE
-void midi_out::set_port_name(std::string_view portName)
+void midi_out::set_port_name(std::string_view portName) const
 {
   impl_->set_port_name(portName);
 }
 
 LIBREMIDI_INLINE
-libremidi::API midi_out::get_current_api() noexcept
+libremidi::API midi_out::get_current_api() const noexcept
 {
   return impl_->get_current_api();
 }
 
 LIBREMIDI_INLINE
-void midi_out::open_port(const output_port& port, std::string_view portName)
+void midi_out::open_port(const output_port& port, std::string_view portName) const
 {
   if (impl_->is_port_open())
     return;
@@ -95,7 +95,7 @@ void midi_out::open_port(const output_port& port, std::string_view portName)
 }
 
 LIBREMIDI_INLINE
-void midi_out::open_virtual_port(std::string_view portName)
+void midi_out::open_virtual_port(std::string_view portName) const
 {
   if (impl_->is_port_open())
     return;
@@ -107,7 +107,7 @@ void midi_out::open_virtual_port(std::string_view portName)
 }
 
 LIBREMIDI_INLINE
-void midi_out::close_port()
+void midi_out::close_port() const
 {
   impl_->close_port();
   impl_->connected_ = false;
@@ -127,87 +127,87 @@ bool midi_out::is_port_connected() const noexcept
 }
 
 LIBREMIDI_INLINE
-void midi_out::send_message(const libremidi::message& message)
+void midi_out::send_message(const libremidi::message& message) const
 {
   send_message(message.bytes.data(), message.bytes.size());
 }
 
 LIBREMIDI_INLINE
-void midi_out::send_message(std::span<const unsigned char> message)
+void midi_out::send_message(std::span<const unsigned char> message) const
 {
   send_message(message.data(), message.size());
 }
 
 LIBREMIDI_INLINE
-void midi_out::send_message(unsigned char b0)
+void midi_out::send_message(unsigned char b0) const
 {
   send_message(&b0, 1);
 }
 
 LIBREMIDI_INLINE
-void midi_out::send_message(unsigned char b0, unsigned char b1)
+void midi_out::send_message(unsigned char b0, unsigned char b1) const
 {
   send_message(std::to_array({b0, b1}));
 }
 
 LIBREMIDI_INLINE
-void midi_out::send_message(unsigned char b0, unsigned char b1, unsigned char b2)
+void midi_out::send_message(unsigned char b0, unsigned char b1, unsigned char b2) const
 {
   send_message(std::to_array({b0, b1, b2}));
 }
 
 LIBREMIDI_INLINE
-void midi_out::send_message(const unsigned char* message, size_t size)
+void midi_out::send_message(const unsigned char* message, size_t size) const
 {
 #if defined(LIBREMIDI_ASSERTIONS)
   assert(size > 0);
 #endif
 
-  (static_cast<midi_out_api*>(impl_.get()))->send_message(message, size);
+  impl_->send_message(message, size);
 }
 
 LIBREMIDI_INLINE
-    void midi_out::send_ump(const uint32_t* message, size_t size)
+    void midi_out::send_ump(const uint32_t* message, size_t size) const
 {
 #if defined(LIBREMIDI_ASSERTIONS)
   assert(size > 0);
   assert(size <= 4);
 #endif
 
-  (static_cast<midi_out_api*>(impl_.get()))->send_ump(message, size);
+  impl_->send_ump(message, size);
 }
 LIBREMIDI_INLINE
-    void midi_out::send_ump(const libremidi::ump& message)
+    void midi_out::send_ump(const libremidi::ump& message) const
 {
   send_ump(message.bytes, message.size());
 }
 
 LIBREMIDI_INLINE
-    void midi_out::send_ump(std::span<const uint32_t> message)
+    void midi_out::send_ump(std::span<const uint32_t> message) const
 {
   send_ump(message.data(), message.size());
 }
 
 LIBREMIDI_INLINE
-    void midi_out::send_ump(uint32_t b0)
+    void midi_out::send_ump(uint32_t b0) const
 {
   send_ump(&b0, 1);
 }
 
 LIBREMIDI_INLINE
-    void midi_out::send_ump(uint32_t b0, uint32_t b1)
+    void midi_out::send_ump(uint32_t b0, uint32_t b1) const
 {
   send_ump(std::to_array({b0, b1}));
 }
 
 LIBREMIDI_INLINE
-    void midi_out::send_ump(uint32_t b0, uint32_t b1, uint32_t b2)
+    void midi_out::send_ump(uint32_t b0, uint32_t b1, uint32_t b2) const
 {
   send_ump(std::to_array({b0, b1, b2}));
 }
 
 LIBREMIDI_INLINE
-    void midi_out::send_ump(uint32_t b0, uint32_t b1, uint32_t b2, uint32_t b3)
+    void midi_out::send_ump(uint32_t b0, uint32_t b1, uint32_t b2, uint32_t b3) const
 {
   send_ump(std::to_array({b0, b1, b2, b3}));
 }

--- a/include/libremidi/midi_out.cpp
+++ b/include/libremidi/midi_out.cpp
@@ -13,7 +13,7 @@ namespace libremidi
 LIBREMIDI_INLINE auto make_midi_out(auto base_conf, std::any api_conf)
 {
   std::unique_ptr<midi_out_api> ptr;
-  auto from_api = [&]<typename T>(T& backend) mutable {
+  auto from_api = [&]<typename T>(T& /*backend*/) mutable {
     if (auto conf = std::any_cast<typename T::midi_out_configuration>(&api_conf))
     {
       ptr = libremidi::make<typename T::midi_out>(std::move(base_conf), std::move(*conf));
@@ -26,7 +26,7 @@ LIBREMIDI_INLINE auto make_midi_out(auto base_conf, std::any api_conf)
   return ptr;
 }
 
-LIBREMIDI_INLINE midi_out::midi_out(output_configuration base_conf) noexcept
+LIBREMIDI_INLINE midi_out::midi_out(const output_configuration& base_conf) noexcept
 {
   for (const auto& api : available_apis())
   {

--- a/include/libremidi/observer.cpp
+++ b/include/libremidi/observer.cpp
@@ -10,7 +10,7 @@ namespace libremidi
 LIBREMIDI_INLINE auto make_observer(auto base_conf, std::any api_conf)
 {
   std::unique_ptr<observer_api> ptr;
-  auto from_api = [&]<typename T>(T& backend) mutable {
+  auto from_api = [&]<typename T>(T& /*backend*/) mutable {
     if (auto conf = std::any_cast<typename T::midi_observer_configuration>(&api_conf))
     {
       ptr = libremidi::make<typename T::midi_observer>(std::move(base_conf), std::move(*conf));
@@ -23,7 +23,7 @@ LIBREMIDI_INLINE auto make_observer(auto base_conf, std::any api_conf)
   return ptr;
 }
 
-LIBREMIDI_INLINE observer::observer(observer_configuration base_conf) noexcept
+LIBREMIDI_INLINE observer::observer(const observer_configuration& base_conf) noexcept
 {
   for (const auto& api : available_apis())
   {

--- a/include/libremidi/reader.hpp
+++ b/include/libremidi/reader.hpp
@@ -55,11 +55,9 @@ public:
 
   parse_result parse(const uint8_t* data, std::size_t size) noexcept;
   parse_result parse(const std::vector<uint8_t>& buffer) noexcept;
-#if defined(LIBREMIDI_HAS_SPAN)
   parse_result parse(std::span<uint8_t> buffer) noexcept;
-#endif
 
-  double get_end_time() const noexcept;
+  [[nodiscard]] double get_end_time() const noexcept;
 
   float ticksPerBeat{}; // precision (number of ticks distinguishable per second)
   float startingTempo{};

--- a/include/libremidi/writer.hpp
+++ b/include/libremidi/writer.hpp
@@ -37,12 +37,12 @@ public:
   int ticksPerQuarterNote{120};
   std::vector<midi_track> tracks;
 
-  void add_event(int tick, int track, message m);
-  void add_event(int track, track_event m);
+  void add_event(int tick, int track, const message& m);
+  void add_event(int track, const track_event& m);
 
   void add_track();
 
-  void write(std::ostream& out);
+  void write(std::ostream& out) const;
 };
 }
 


### PR DESCRIPTION
for #90
There might also be a couple of extra changes since at first I just copied over the warnings I had enabled in my project which enables a lot more than just -Wall and -Wextra. 
I'd personally also recommend enabling -Wpedantic as that will tell GCC and clang to strictly follow the standard which helps make sure you don't accidentally use a compiler extension allowing the code to (for the most part) compile on all standard compliant compilers.
For reference, these are that flags I personally use
```
-Werror -Wall -Wextra -Wpedantic -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2
-Winit-self  -Wmissing-declarations  -Wmissing-include-dirs  -Wold-style-cast -Woverloaded-virtual -Wredundant-decls
-Wshadow -Wsign-conversion -Wsign-promo -Wstrict-overflow=5 -Wswitch-default -Wundef -Wzero-as-null-pointer-constant
```