### PR TITLE
[coremidi] Fix iOS support by declaring custom host time macro

### DIFF
--- a/include/libremidi/backends/coremidi.hpp
+++ b/include/libremidi/backends/coremidi.hpp
@@ -20,7 +20,3 @@ struct core_backend
   static constexpr inline bool available() noexcept { return true; }
 };
 }
-
-#if TARGET_OS_IPHONE
-  #undef AudioGetCurrentHostTime
-#endif

--- a/include/libremidi/backends/coremidi/helpers.hpp
+++ b/include/libremidi/backends/coremidi/helpers.hpp
@@ -12,9 +12,10 @@
 #if TARGET_OS_IPHONE
   #include <CoreAudio/CoreAudioTypes.h>
   #include <mach/mach_time.h>
-  #define AudioGetCurrentHostTime mach_absolute_time
+  #define LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME mach_absolute_time
 #else
   #include <CoreAudio/HostTime.h>
+  #define LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME AudioGetCurrentHostTime
 #endif
 
 namespace libremidi

--- a/include/libremidi/backends/coremidi/midi_in.hpp
+++ b/include/libremidi/backends/coremidi/midi_in.hpp
@@ -132,7 +132,7 @@ public:
 
   int64_t absolute_timestamp() const noexcept override
   {
-    return coremidi_data::time_in_nanos(AudioGetCurrentHostTime());
+    return coremidi_data::time_in_nanos(LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME());
   }
 
   static void midiInputCallback(const MIDIPacketList* list, void* procRef, void* /*srcRef*/)

--- a/include/libremidi/backends/coremidi/midi_out.hpp
+++ b/include/libremidi/backends/coremidi/midi_out.hpp
@@ -144,7 +144,7 @@ public:
       return;
     }
 
-    const MIDITimeStamp timestamp = AudioGetCurrentHostTime();
+    const MIDITimeStamp timestamp = LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME();
 
     const ByteCount bufsize = nBytes > 65535 ? 65535 : nBytes;
     Byte buffer[bufsize + 16]; // pad for other struct members

--- a/include/libremidi/backends/coremidi_ump.hpp
+++ b/include/libremidi/backends/coremidi_ump.hpp
@@ -20,6 +20,3 @@ struct backend
   static constexpr inline bool available() noexcept { return true; /* todo? */ }
 };
 }
-#if TARGET_OS_IPHONE
-  #undef AudioGetCurrentHostTime
-#endif

--- a/include/libremidi/backends/coremidi_ump/midi_in.hpp
+++ b/include/libremidi/backends/coremidi_ump/midi_in.hpp
@@ -146,7 +146,7 @@ public:
 
   int64_t absolute_timestamp() const noexcept override
   {
-    return coremidi_data::time_in_nanos(AudioGetCurrentHostTime());
+    return coremidi_data::time_in_nanos(LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME());
   }
 
   void midiInputCallback(const MIDIEventList* list, void* /*srcRef*/)

--- a/include/libremidi/backends/coremidi_ump/midi_out.hpp
+++ b/include/libremidi/backends/coremidi_ump/midi_out.hpp
@@ -137,7 +137,7 @@ public:
 
     MIDIEventList eventList = {};
     MIDIEventPacket* packet = MIDIEventListInit(&eventList, kMIDIProtocol_2_0);
-    MIDITimeStamp ts = AudioGetCurrentHostTime();
+    MIDITimeStamp ts = LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME();
     const auto sz = cmidi2_ump_get_num_bytes(ump[0]) / 4;
 
     // And send to an explicit destination port if we're connected.


### PR DESCRIPTION
Building for iOS, e.g. with `cmake -B build -DCMAKE_SYSTEM_NAME=iOS && cmake --build build` currently results in an error:

```
[7/12] Building CXX object CMakeFiles/libremidi.dir/include/libremidi/observer.cpp.o
FAILED: CMakeFiles/libremidi.dir/include/libremidi/observer.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DLIBREMIDI_COREMIDI -DLIBREMIDI_EXPORTS -I<path to libremidi>/build -I<path to libremidi> -I<path to libremidi>/include -F/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.2.sdk/System/Library/Frameworks -std=gnu++20 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.2.sdk -fPIC -Wall -Wextra -MD -MT CMakeFiles/libremidi.dir/include/libremidi/observer.cpp.o -MF CMakeFiles/libremidi.dir/include/libremidi/observer.cpp.o.d -o CMakeFiles/libremidi.dir/include/libremidi/observer.cpp.o -c <path to libremidi>/include/libremidi/observer.cpp
In file included from <path to libremidi>/include/libremidi/observer.cpp:5:
In file included from <path to libremidi>/include/libremidi/backends.hpp:34:
In file included from <path to libremidi>/include/libremidi/backends/coremidi_ump.hpp:2:
<path to libremidi>/include/libremidi/backends/coremidi_ump/midi_in.hpp:149:41: error: use of undeclared identifier 'AudioGetCurrentHostTime'
    return coremidi_data::time_in_nanos(AudioGetCurrentHostTime());
                                        ^
In file included from <path to libremidi>/include/libremidi/observer.cpp:5:
In file included from <path to libremidi>/include/libremidi/backends.hpp:34:
In file included from <path to libremidi>/include/libremidi/backends/coremidi_ump.hpp:3:
<path to libremidi>/include/libremidi/backends/coremidi_ump/midi_out.hpp:140:24: error: use of undeclared identifier 'AudioGetCurrentHostTime'
    MIDITimeStamp ts = AudioGetCurrentHostTime();
                       ^
2 errors generated.
```

The issue is that while the library defines

https://github.com/jcelerier/libremidi/blob/bbf046fca82c5c088d50682e99526a144f1277c2/include/libremidi/backends/coremidi/helpers.hpp#L12-L18

... it `#undef`s the macro at the end of `coremidi.hpp`...

https://github.com/jcelerier/libremidi/blob/bbf046fca82c5c088d50682e99526a144f1277c2/include/libremidi/backends/coremidi.hpp#L24-L26

...which thus never reaches use sites such as `midi_in.hpp`:

https://github.com/jcelerier/libremidi/blob/bbf046fca82c5c088d50682e99526a144f1277c2/include/libremidi/backends/coremidi/midi_in.hpp#L135

I presume, the macro was `#undef`ed to avoid redefining the symbol for downstream library consumers, which is a good idea in principle, but would require defining and undefining the macro in every header/source file where it is used.

To fix this issue, this PR declares a new `LIBREMIDI_AUDIO_GET_CURRENT_HOST_TIME` macro, on all platforms, using the corresponding implementation and removes the `#undef` which, due to the `LIBREMIDI_` prefix, should no longer be required.